### PR TITLE
Update to give more options for the UVM report macros

### DIFF
--- a/snippets/uvm_macros.json
+++ b/snippets/uvm_macros.json
@@ -20,6 +20,26 @@
     "body": ["`uvm_fatal(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \"${2:message}\")\n$0"],
     "description": "Calls uvm_report_fatal with a verbosity of UVM_NONE. ID is given as the message tag and message is given as the message text. The file and line are also sent to the uvm_report_fatal call."
   },
+  "uvm_macro_info_sformatf": {
+    "prefix": "uvm_info_sformatf",
+    "body": ["`uvm_info(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \\$sformatf(\"${2:message}\",$3), ${4|UVM_NONE,UVM_LOW,UVM_MEDIUM,UVM_HIGH,UVM_FULL,UVM_DEBUG|})\n$0"],
+    "description": "Calls uvm_report_info if VERBOSITY is lower than the configured verbosity of the associated reporter. ID is given as the message tag and message is formatted using the sformatf construct and given as the message text. The file and line are also sent to the uvm_report_info call."
+  },
+  "uvm_macro_warning_sformatf": {
+    "prefix": "uvm_warning_sformatf",
+    "body": ["`uvm_warning(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \\$sformatf(\"${2:message}\",$3))\n$0"],
+    "description": "Calls uvm_report_warning with a verbosity of UVM_NONE. ID is given as the message tag and message is formatted using the sformatf construct and given as the message text. The file and line are also sent to the uvm_report_warning call."
+  },
+  "uvm_macro_error_sformatf": {
+    "prefix": "uvm_error_sformatf",
+    "body": ["`uvm_error(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \\$sformatf(\"${2:message}\",$3))\n$0"],
+    "description": "Calls uvm_report_error with a verbosity of UVM_NONE. ID is given as the message tag and message is formatted using the sformatf construct and given as the message text. The file and line are also sent to the uvm_report_error call."
+  },
+  "uvm_macro_fatal_sformatf": {
+    "prefix": "uvm_fatal_sformatf",
+    "body": ["`uvm_fatal(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \\$sformatf(\"${2:message}\",$3))\n$0"],
+    "description": "Calls uvm_report_fatal with a verbosity of UVM_NONE. ID is given as the message tag and message is formatted using the sformatf construct and given as the message text. The file and line are also sent to the uvm_report_fatal call."
+  },
 
   // FACTORY RELATED MACROS
   "uvm_macro_object_utils": {

--- a/snippets/uvm_macros.json
+++ b/snippets/uvm_macros.json
@@ -2,22 +2,22 @@
   // REPORT MACROS
   "uvm_macro_info": {
     "prefix": "uvm_info",
-    "body": ["`uvm_info(${1|get_name(),get_full_name(),\"\"|}, \"${2:message}\", ${3|UVM_NONE,UVM_LOW,UVM_MEDIUM,UVM_HIGH,UVM_FULL,UVM_DEBUG|})\n$0"],
+    "body": ["`uvm_info(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \"${2:message}\", ${3|UVM_NONE,UVM_LOW,UVM_MEDIUM,UVM_HIGH,UVM_FULL,UVM_DEBUG|})\n$0"],
     "description": "Calls uvm_report_info if VERBOSITY is lower than the configured verbosity of the associated reporter. ID is given as the message tag and message is given as the message text. The file and line are also sent to the uvm_report_info call."
   },
   "uvm_macro_warning": {
     "prefix": "uvm_warning",
-    "body": ["`uvm_warning(${1|get_name(),get_full_name(),\"\"|}, \"${2:message}\")\n$0"],
+    "body": ["`uvm_warning(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \"${2:message}\")\n$0"],
     "description": "Calls uvm_report_warning with a verbosity of UVM_NONE. ID is given as the message tag and message is given as the message text. The file and line are also sent to the uvm_report_warning call."
   },
   "uvm_macro_error": {
     "prefix": "uvm_error",
-    "body": ["`uvm_error(${1|get_name(),get_full_name(),\"\"|}, \"${2:message}\")\n$0"],
+    "body": ["`uvm_error(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \"${2:message}\")\n$0"],
     "description": "Calls uvm_report_error with a verbosity of UVM_NONE. ID is given as the message tag and message is given as the message text. The file and line are also sent to the uvm_report_error call."
   },
   "uvm_macro_fatal": {
     "prefix": "uvm_fatal",
-    "body": ["`uvm_fatal(${1|get_name(),get_full_name(),\"\"|}, \"${2:message}\")\n$0"],
+    "body": ["`uvm_fatal(${1|get_name(),get_full_name(),get_type_name(),\"\"|}, \"${2:message}\")\n$0"],
     "description": "Calls uvm_report_fatal with a verbosity of UVM_NONE. ID is given as the message tag and message is given as the message text. The file and line are also sent to the uvm_report_fatal call."
   },
 


### PR DESCRIPTION
I added the option to choose get_type_name() in the ID field of the UVM report macros
Also I added sformatf version of all report macros to easier enable us to write formatted messages using the report macros